### PR TITLE
TB-117 Add action for checking PR titles

### DIFF
--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -1,0 +1,16 @@
+name: Checks Pull-Request titles
+
+on:
+  pull_request:
+    branches: [ main ]
+    types: [opened, edited, synchronize, reopened]
+
+jobs:
+  title-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: deepakputhraya/action-pr-title@master
+        with:
+          min_length: 6 # Min length of the title
+          max_length: 72 # Max length of the title
+          github_token: ${{ github.token }} # Default: ${{ github.token }}


### PR DESCRIPTION
TB-117

## AS-IS
No rule for PR titles

## TO-BE
PR title length is limited within ~ [6, 72].
6 is the length for the JIRA issue IDs of Annotation-AI.