### PR TITLE
Update configs for further uses

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+# Python Project Template
+This repository is a python template repo for internal uses of Annotation-AI.
+
 ## File Structure
 ```bash
 .

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,6 @@ flake8-docstrings   == 1.6.0    # pydocstyle tool to flake8
 flake8-annotations  == 2.7.0    # PEP 3107-style function annotations
 flake8-builtins     == 1.5.3    # check python builtins being used as variables or parameters
 flake8-bugbear      == 22.1.11  # find likely bugs and design problems
-flake8-spellcheck   == 0.24.0   # spellcheck variables, functions, classes and others
 
 # pytest for linting and unit test
 pytest          == 6.2.5

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,7 +6,7 @@ profile = black
 
 [flake8]
 max-line-length = 88
-extend-ignore = E203, ANN101, SC100
+extend-ignore = E203, ANN101
 
 [pylint]
 max-line-length = 88

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,11 +6,11 @@ profile = black
 
 [flake8]
 max-line-length = 88
-extend-ignore = E203
-spellcheck-targets=comments
+extend-ignore = E203, ANN101, SC100
 
 [pylint]
 max-line-length = 88
+extension-pkg-whitelist=pydantic
 
 [pylint.messages_control]
 # https://vald-phoenix.github.io/pylint-errors/#list-of-errors
@@ -18,6 +18,11 @@ disable =
     C0330,  # bad-continuation
     C0326,  # bad-whitespace
     C0411,  # wrong-import-order
+
+[pylint.typecheck]
+# List of members which are set dynamically and missed by Pylint inference
+# system, and so shouldn't trigger E1101 when accessed.
+generated-members=numpy.*, torch.*
 
 [mypy]
 ignore_missing_imports = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,7 +10,7 @@ extend-ignore = E203, ANN101
 
 [pylint]
 max-line-length = 88
-extension-pkg-whitelist=pydantic
+extension-pkg-whitelist=pydantic  # need for fastapi
 
 [pylint.messages_control]
 # https://vald-phoenix.github.io/pylint-errors/#list-of-errors


### PR DESCRIPTION
Fix #8 

## Updates
- deprecated flake8-spellcheck.
- deprecated some pylint checks which are not recommended.
- updated type check information for the frequently used packages.
- added statement for this repo in README.md